### PR TITLE
fix(Core/Commands): fix reload creature_template and creature movment

### DIFF
--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -456,7 +456,7 @@ public:
             cInfo->faction            = fields[16].GetUInt16();
             cInfo->npcflag            = fields[17].GetUInt32();
             cInfo->speed_walk         = fields[18].GetFloat();
-            cInfo->speed_run          = fields[29].GetFloat();
+            cInfo->speed_run          = fields[19].GetFloat();
             cInfo->scale              = fields[20].GetFloat();
             cInfo->rank               = fields[21].GetUInt8();
             cInfo->mindmg             = fields[22].GetFloat();


### PR DESCRIPTION
Reloading an existing creature with .reload creature_template will most of the time cause the error "MoveSplineInitArgs::Validate: expression 'velocity > 0.01f' failed for GUID..." when the NPC tries to move afterward without a proper server restart.

Caused because the cInfo->speed_run was calling the field 29 for whatever reason.

<!-- First of all, THANK YOU for your contribution.
 Please fill this template unless your PR is very simple/straightforward.
 Do not forget to have a look at our Pull Request tutorial: http://www.azerothcore.org/wiki/Contribute#how-to-create-a-pull-request
-->


<!-- WRITE A RELEVANT TITLE -->


##### CHANGES PROPOSED:

-  
-  


###### ISSUES ADDRESSED:
<!-- If the issue doesn't exist, describe it and how to reproduce it, please. If the issue already exists, just paste the link to the issue you close, like this: Closes https://github.com/azerothcore/azerothcore-wotlk/issues/967 -->

Closes 


##### TESTS PERFORMED:
<!-- Does it build without errors? Did you test in-game? What did you test? Did you do all these tests on Linux, Mac or Windows? Other tests performed -->



##### HOW TO TEST THE CHANGES:
<!-- We need to confirm the changes first, so try to make the work easy for testers, please:
 - Which commands to use? Which NPC to teleport to?
 - Do we need to enable debug flags on Cmake?
 - Do we need to look at the console? etc...
 - Other steps
-->



##### KNOWN ISSUES AND TODO LIST:
<!-- This is a TODO list with checkboxes to tick -->

- [ ]
- [ ] 


##### Target branch(es):

Master


<!-- NOTE: You no longer need to squash your commits, on merge we will squash them for you (when there are too many commits we merge them into one big commit for a cleaner and easy to read history). -->

<!-- NOTE2: If you intend to contribute more than once, you should really join us on our discord channel!
 The link is on our site http://azerothcore.org/ We set cosmetic ranks for our contributors and may give access to special resources/knowledge to them! -->
